### PR TITLE
434381: Added a complimentary fix to check default profile if policy …

### DIFF
--- a/infra/scripts/Set-AFDSecurityPolicy.ps1
+++ b/infra/scripts/Set-AFDSecurityPolicy.ps1
@@ -76,11 +76,11 @@ try {
     $securityPolicies = Get-AzFrontDoorCdnSecurityPolicy -ResourceGroupName $ResourceGroupName -ProfileName $AfdName -SubscriptionId $SubscriptionId
     $securityPolicy = $securityPolicies | Where-Object { $_.Name -eq $PolicyName }
 
-    <# Complimentary fix to check the security policy exists in the old 'default' Azure Front Door Name (afdName) if we cannot find it.
+    <# Complimentary fix to check the security policy exists in the old 'default' Azure Front Door Name (PolicyName) if we cannot find it.
        We will raise a story to look into addressing how we change the default name without exposing services to the public internet   #>
     if (-not $securityPolicy) {
-        $securityPolicies = Get-AzFrontDoorCdnSecurityPolicy -ResourceGroupName $ResourceGroupName -ProfileName 'default' -SubscriptionId $SubscriptionId
-        $securityPolicy = $securityPolicies | Where-Object { $_.Name -eq $PolicyName }
+        $securityPolicies = Get-AzFrontDoorCdnSecurityPolicy -ResourceGroupName $ResourceGroupName -ProfileName $AfdName -SubscriptionId $SubscriptionId
+        $securityPolicy = $securityPolicies | Where-Object { $_.Name -eq 'default' }
     }
 
     if ($securityPolicy) {

--- a/infra/scripts/Set-AFDSecurityPolicy.ps1
+++ b/infra/scripts/Set-AFDSecurityPolicy.ps1
@@ -106,7 +106,7 @@ try {
             Update-AzFrontDoorCdnSecurityPolicy -ResourceGroupName $ResourceGroupName -ProfileName $AfdName -Name $usedlPolicyName -Parameter $wafParameter
         }
         else {
-            Write-Output "Domain '$CustomDomainName' is already associated to a security policy '$usedlPolicyName' or default."
+            Write-Output "Domain '$CustomDomainName' is already associated to a security policy '$usedlPolicyName'."
         }
     }
     else {

--- a/infra/scripts/Set-AFDSecurityPolicy.ps1
+++ b/infra/scripts/Set-AFDSecurityPolicy.ps1
@@ -76,6 +76,13 @@ try {
     $securityPolicies = Get-AzFrontDoorCdnSecurityPolicy -ResourceGroupName $ResourceGroupName -ProfileName $AfdName -SubscriptionId $SubscriptionId
     $securityPolicy = $securityPolicies | Where-Object { $_.Name -eq $PolicyName }
 
+    <# Complimentary fix to check the security policy exists in the old 'default' Azure Front Door Name (afdName) if we cannot find it.
+       We will raise a story to look into addressing how we change the default name without exposing services to the public internet   #>
+    if (-not $securityPolicy) {
+        $securityPolicies = Get-AzFrontDoorCdnSecurityPolicy -ResourceGroupName $ResourceGroupName -ProfileName 'default' -SubscriptionId $SubscriptionId
+        $securityPolicy = $securityPolicies | Where-Object { $_.Name -eq $PolicyName }
+    }
+
     if ($securityPolicy) {
         $exists = $false
         $domains = @()


### PR DESCRIPTION
# **What this PR does / why we need it**:
Fix the WAF firewall rule failing due to 'default' policy consuming the Security Policy Name.

*A brief description of changes being made*
This is an interim fix, to check if the security policy exists in the default policy, if it not found in the named policy.  This will make sure the rule is added.
[AB#434381](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/434381)

# **Special notes for your reviewer**
Future tickets will be raised to improve on the process.

# Testing
[*Any relevant testing information and pipeline runs.*](https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=665556&view=results)
https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=665549&view=results
Run against SND1 - 
Existing dns skipped.  
Send run non-existing DNS added.

WIP

# Checklist (please delete before completing or setting auto-complete)
- [ ] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [ ] Title pattern should be `{work item number}: {title}`
- [ ] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests
